### PR TITLE
v3.1.0 fix trailing blank line

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,5 +1,5 @@
 name: pytest
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
@@ -593,6 +593,20 @@ class TestDXManageReadDXfile():
             DXManage().read_dxfile(file='invalid_str')
 
 
+    @patch('utils.dx_requests.dxpy.DXFile')
+    def test_trailing_blank_line_removed(self, mock_file):
+        """
+        If the file has a blank line at the end this would result in
+        the file being read into a list with an empty string at the
+        end => test that we correctly remove this
+        """
+        mock_file.return_value.read.return_value = 'line1\nline2\nline3\n'
+
+        contents = DXManage().read_dxfile(file='project-xxx:file-xxx')
+
+        assert contents == ['line1', 'line2', 'line3']
+
+
 class TestDXManageCheckArchivalState():
     """
     Tests for DXManage.check_archival_state()

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -335,7 +335,8 @@ class DXManage():
             f"project: {project}, file: {file_id}"
         )
 
-        return dxpy.DXFile(project=project, dxid=file_id).read().split('\n')
+        return dxpy.DXFile(
+            project=project, dxid=file_id).read().rstrip('\n').split('\n')
 
 
     def check_archival_state(self, files, unarchive, samples=None) -> None:


### PR DESCRIPTION
Fixes issue where a trailing blank line in a file would result in the file contents having an empty string when read in, this would break excluding samples as all files would match the empty string and be excluded

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_dias_batch/174)
<!-- Reviewable:end -->
