### PR TITLE
v3.1.0 - tidy up manifest logging

### DIFF
--- a/resources/home/dnanexus/dias_batch/dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/dias_batch.py
@@ -324,7 +324,8 @@ def main(
         manifest = {}
         manifest_source = {}
 
-        for file in manifest_files:
+        for idx, file in enumerate(manifest_files, 1):
+            print(f"Parsing file {idx}/{len(manifest_files)}")
             manifest_data = DXManage().read_dxfile(file)
             manifest_data, source = parse_manifest(
                 contents=manifest_data,
@@ -336,8 +337,8 @@ def main(
             manifest = {**manifest, **manifest_data}
             manifest_source = {**manifest_source, **source}
 
-        print("Parsed manifest(s)")
-        prettier_print(manifest)
+        print("Parsed manifest(s):")
+        print('⠀⠀', '\n⠀⠀⠀'.join({f"{k}: {v}" for k, v in manifest.items()}))
 
         # filter manifest tests against genepanels to ensure what has been
         # requested are test codes or HGNC IDs we recognise


### PR DESCRIPTION
minor change to reduce lines in log file from pretty printing the parsed manifest(s)

before: 
![image](https://github.com/eastgenomics/eggd_dias_batch/assets/45037268/bbc38036-5cdc-4d7a-abe1-17eacad9623f)

after: 
![image](https://github.com/eastgenomics/eggd_dias_batch/assets/45037268/e88f2056-96a1-4c70-97fa-f4048454adeb)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_dias_batch/177)
<!-- Reviewable:end -->
