### PR TITLE
v3.1.0 - add optional multiqc_report input for eggd_artemis

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -46,6 +46,13 @@
             "help": "QC .xlsx file. optional input to eggd_artemis"
           },
           {
+            "name": "multiqc_report",
+            "label": "MultiQC report",
+            "class": "file",
+            "optional": true,
+            "help": "MultiQC report, optional input to eggd_artemis"
+          },
+          {
             "name": "split_tests",
             "label": "split tests",
             "class": "boolean",

--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,7 @@ DNAnexus app for launching CNV calling, one or more of SNV, CNV and mosaic repor
 
 **Files**
 - `-iqc_file` (`file`): xlsx file mapping QC state of each sample (_this is an optional input file for eggd\_artemis, and will only be used when `-iartemis=true` specified_)
+- `-imultiqc_report` (`file`): HTML MultiQC report (_this is an optional input file for eggd\_artemis and will pass the file as input to suppress searching for a MultiQC job in the project_)
 - `-iassay_config_file` (`file`): Config file for assay, if not provided will search default `assay_config_dir` for highest version config file for the given `-assay` string
 - `-iexclude_samples_file` (`file`): file of samples to exclude from CNV calling / CNV reports, one sample name per line. Epic samples should be formatted as `InstrumentID-SpecimenID` (i.e. `123245111-33202R00111`) Example formatting of exclude_samples_file`:
     ```
@@ -283,7 +284,7 @@ The definitions of inputs for CNV calling and each reports workflow should be de
     - inputs may be defined as regular integers / strings / booleans, `$dnanexus_link` file mappings or using `INPUT-` placeholders
     - `INPUT-` placeholders are followed by a reference key from the `reference_files` mapping in the top level of the config file, and are parsed at run time into the inputs for the workflow (i.e. use of `"stage-cnv_generate_bed_vep.gene_panels": "INPUT-genepanels"` would result be replace by `project-Fkb6Gkj433GVVvj73J7x8KbV:file-GVx0vkQ433Gvq63k1Kj4Y562`, correctly formatted as a `$dnanexus_link` mapping)
     - inputs for the following stages follow the same behaviour as the `bambais` input for the CNV calling app of being provided as a "folder" and "name" key for searching:
-        - cnv_reports: 
+        - cnv_reports:
             - `stage-cnv_vep.vcf`
         - snv_reports and mosaic_reports
             - `stage-rpt_vep.vcf`

--- a/readme.md
+++ b/readme.md
@@ -25,8 +25,8 @@ DNAnexus app for launching CNV calling, one or more of SNV, CNV and mosaic repor
 - `-imanifest_subset` (`str`): comma separated string of Epic samples in manifest on which to ONLY run jobs (these should be formatted as `InstrumentID-SpecimenID` (i.e. `123245111-33202R00111`)). This option is to be used if an Epic batch had mistakes in the manifest, which have now been corrected. This will filter the updated batch so that reports jobs are only run for the corrected samples and not the whole batch.
 
 **Files**
-- `-iqc_file` (`file`): xlsx file mapping QC state of each sample (_this is an optional input file for eggd\_artemis, and will only be used when `-iartemis=true` specified_)
-- `-imultiqc_report` (`file`): HTML MultiQC report (_this is an optional input file for eggd\_artemis and will pass the file as input to suppress searching for a MultiQC job in the project_)
+- `-iqc_file` (`file`): xlsx file mapping QC state of each sample (_this is an optional input file for eggd\_artemis, and should only be specified with `-iartemis=true`_)
+- `-imultiqc_report` (`file`): HTML MultiQC report (_this is an optional input file for eggd\_artemis and should only be specified with `-iartemis=true`, it will pass the file as input to suppress searching for a MultiQC job in the project_)
 - `-iassay_config_file` (`file`): Config file for assay, if not provided will search default `assay_config_dir` for highest version config file for the given `-assay` string
 - `-iexclude_samples_file` (`file`): file of samples to exclude from CNV calling / CNV reports, one sample name per line. Epic samples should be formatted as `InstrumentID-SpecimenID` (i.e. `123245111-33202R00111`) Example formatting of exclude_samples_file`:
     ```

--- a/resources/home/dnanexus/dias_batch/dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/dias_batch.py
@@ -271,6 +271,7 @@ def main(
     mosaic_reports=False,
     artemis=False,
     qc_file=None,
+    multiqc_report=None,
     testing=False,
     sample_limit=None,
     unarchive=None
@@ -467,7 +468,8 @@ def main(
                 snv_output=snv_path,
                 cnv_output=cnv_path,
                 capture_bed=assay_config['modes']['artemis']['inputs']['capture_bed'],
-                url_duration=url_duration
+                url_duration=url_duration,
+                multiqc_report=multiqc_report
             )
 
             launched_jobs['artemis'] = [artemis_job]

--- a/resources/home/dnanexus/dias_batch/dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/dias_batch.py
@@ -363,7 +363,7 @@ def main(
     launched_jobs = {}
     cnv_report_errors = snv_report_errors = mosaic_report_errors = \
         cnv_call_excluded_files = cnv_report_summary = snv_report_summary = \
-            mosaic_report_summary = None
+        mosaic_report_summary = None
 
     # set downstream jobs to be dependent on parent batch job, wonderfully
     # hacky way to not actually start any downstream jobs in testing mode and

--- a/resources/home/dnanexus/dias_batch/dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/dias_batch.py
@@ -362,7 +362,8 @@ def main(
 
     launched_jobs = {}
     cnv_report_errors = snv_report_errors = mosaic_report_errors = \
-        cnv_report_summary = snv_report_summary = mosaic_report_summary = None
+        cnv_call_excluded_files = cnv_report_summary = snv_report_summary = \
+            mosaic_report_summary = None
 
     # set downstream jobs to be dependent on parent batch job, wonderfully
     # hacky way to not actually start any downstream jobs in testing mode and

--- a/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
@@ -1955,7 +1955,7 @@ class TestDXExecuteReportsWorkflow(unittest.TestCase):
         )
 
 
-class TestDXExecuteArtemis():
+class TestDXExecuteArtemis(unittest.TestCase):
     """
     Test for DXExecute.artemis
 
@@ -1966,7 +1966,7 @@ class TestDXExecuteArtemis():
     """
 
     @patch('utils.dx_requests.make_path')
-    @patch('utils.dx_requests.dxpy.DXApp.describe')
+    @patch('utils.dx_requests.dxpy.describe')
     @patch('utils.dx_requests.dxpy.DXApp')
     def test_called(
         self,
@@ -1983,6 +1983,11 @@ class TestDXExecuteArtemis():
         job_obj._dxid = 'job-QaTZ9qEwkEsovKLs14DSdNqb'
         mock_app.return_value.run.return_value = job_obj
 
+        mock_describe.return_value = {
+            'name': 'eggd_artemis',
+            'version': '1.3.0'
+        }
+
         job = DXExecute().artemis(
             single_output_dir='/output_path/',
             app_id='app-xxx',
@@ -1998,6 +2003,42 @@ class TestDXExecuteArtemis():
         assert job == 'job-QaTZ9qEwkEsovKLs14DSdNqb', (
             'Job ID returned from running Artemis incorrect'
         )
+
+    @patch('utils.dx_requests.make_path')
+    @patch('utils.dx_requests.dxpy.describe')
+    @patch('utils.dx_requests.dxpy.DXApp')
+    def test_multiqc_report_added(
+        self,
+        mock_app,
+        mock_describe,
+        mock_path
+    ):
+        """
+        Test that when eggd_artemis >=1.4.0 that multiqc_report is
+        specified as an input when running the app
+        """
+        # mock app describe output to be 1.4.0 => add multiqc_report
+        mock_describe.return_value = {
+            'name': 'eggd_artemis',
+            'version': '1.4.0'
+        }
+
+        DXExecute().artemis(
+            single_output_dir='/output_path/',
+            app_id='app-xxx',
+            dependent_jobs=[],
+            start='230922_1012',
+            qc_xlsx='file-xxx',
+            capture_bed='file-xxx',
+            snv_output=None,
+            cnv_output=None,
+            url_duration=None,
+            multiqc_report='file-xxx'
+        )
+
+        run_input = mock_app.return_value.run.call_args.kwargs
+
+        self.assertEqual(run_input['app_input']['multiqc_report'], 'file-xxx')
 
 
 class TestDXExecuteTerminate(unittest.TestCase):

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -1255,9 +1255,11 @@ class DXExecute():
             "cnv_path": cnv_output,
             "qc_status": qc_xlsx,
             "bed_file": capture_bed,
-            "url_duration": url_duration,
-            "multiqc_report": multiqc_report
+            "url_duration": url_duration
         }
+
+        if details.get('version') >= '1.4.0':
+            app_input["multiqc_report"] = multiqc_report
 
         job = dxpy.DXApp(dxid=app_id).run(
             app_input=app_input,

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -1213,7 +1213,8 @@ class DXExecute():
             capture_bed,
             snv_output=None,
             cnv_output=None,
-            url_duration=None
+            url_duration=None,
+            multiqc_report=None
         ) -> str:
         """
         Launch eggd_artemis to generate xlsx file of download links
@@ -1238,6 +1239,8 @@ class DXExecute():
             output path of CNV reports (if run), by default None
         url_duration : str (optional)
             expiry time in seconds for artemis urls, by default None
+        multiqc_report : str (optional)
+            file ID of MultiQC report to specify as input
 
         Returns
         -------
@@ -1252,7 +1255,8 @@ class DXExecute():
             "cnv_path": cnv_output,
             "qc_status": qc_xlsx,
             "bed_file": capture_bed,
-            "url_duration": url_duration
+            "url_duration": url_duration,
+            "multiqc_report": multiqc_report
         }
 
         job = dxpy.DXApp(dxid=app_id).run(

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -1247,7 +1247,7 @@ class DXExecute():
         str
             job ID of launched job
         """
-        details = dxpy.DXApp(app_id).describe()
+        details = dxpy.describe(app_id)
         path = make_path(single_output_dir, details['name'], start)
 
         app_input = {

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -1247,6 +1247,7 @@ class DXExecute():
         str
             job ID of launched job
         """
+        print("Launching eggd_artemis")
         details = dxpy.describe(app_id)
         path = make_path(single_output_dir, details['name'], start)
 
@@ -1260,6 +1261,8 @@ class DXExecute():
 
         if details.get('version') >= '1.4.0':
             app_input["multiqc_report"] = multiqc_report
+
+        print(f"Inputs for eggd_artemis:\n{prettier_print(app_input)}")
 
         job = dxpy.DXApp(dxid=app_id).run(
             app_input=app_input,

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -1262,7 +1262,8 @@ class DXExecute():
         if details.get('version') >= '1.4.0' and multiqc_report:
             app_input["multiqc_report"] = multiqc_report
 
-        print(f"Inputs for eggd_artemis:\n{prettier_print(app_input)}")
+        print("Inputs for eggd_artemis:")
+        print(prettier_print(app_input))
 
         job = dxpy.DXApp(dxid=app_id).run(
             app_input=app_input,

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -1263,7 +1263,7 @@ class DXExecute():
             app_input["multiqc_report"] = multiqc_report
 
         print("Inputs for eggd_artemis:")
-        print(prettier_print(app_input))
+        prettier_print(app_input)
 
         job = dxpy.DXApp(dxid=app_id).run(
             app_input=app_input,

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -1259,7 +1259,7 @@ class DXExecute():
             "url_duration": url_duration
         }
 
-        if details.get('version') >= '1.4.0':
+        if details.get('version') >= '1.4.0' and multiqc_report:
             app_input["multiqc_report"] = multiqc_report
 
         print(f"Inputs for eggd_artemis:\n{prettier_print(app_input)}")


### PR DESCRIPTION
- adds optional app input `-imultiqc_report` to be able to specify a multiQC report to eggd_artemis >=1.4.0
- fixes #179 
- test job with current config `-imultiqc_report`: https://platform.dnanexus.com/panx/projects/GfBY2K84bkgxbx7y3z6q83k9/monitor/job/GfY6x3Q4bkgQBG2GxjzVzQV3
- n.b. not tested trying to run eggd_artemis/1.4.0 since DNAnexus doesn't want to allow an unpublished app to be run from an app environment, have added additional unit test to show when new version of eggd_artemis is used that the multiqc_report file ID is passed into the job inputs

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_dias_batch/180)
<!-- Reviewable:end -->
