### PR TITLE
v3.1.0 - error on multiple configs

### DIFF
--- a/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
@@ -314,7 +314,7 @@ class TestDXManageGetAssayConfig(unittest.TestCase):
         self.mock_file.return_value = dxpy.DXFile
 
         # patch the output from DXFile.read() to simulate looping over
-        # the return of reading multiple configs
+        # the return of reading multiple configs with 2 of the same version
         self.mock_loads.side_effect = [
             {'assay': 'test', 'version': '1.0.0'},
             {'assay': 'test', 'version': '1.1.0'},
@@ -323,8 +323,8 @@ class TestDXManageGetAssayConfig(unittest.TestCase):
 
         expected_error = (
             "Error: more than one file found for highest version of test "
-            "configs. Files found:\\n\\tconfig2.json \(file-yyy\)\\n\\t"
-            "config3.json \(file-zzz\)"
+            r"configs. Files found:\\n\\tconfig2.json \(file-yyy\)\\n\\t"
+            r"config3.json \(file-zzz\)"
         )
 
         with pytest.raises(RuntimeError, match=expected_error):

--- a/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
@@ -11,7 +11,6 @@ from unittest import mock
 from unittest.mock import patch
 
 import dxpy
-import pandas as pd
 import pytest
 
 

--- a/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
@@ -11,6 +11,7 @@ from unittest import mock
 from unittest.mock import patch
 
 import dxpy
+import pandas as pd
 import pytest
 
 
@@ -322,8 +323,8 @@ class TestDXManageGetAssayConfig(unittest.TestCase):
 
         expected_error = (
             "Error: more than one file found for highest version of test "
-            r"configs. Files found:\\n\\tconfig2.json \(file-yyy\)\\n\\t"
-            r"config3.json \(file-zzz\)"
+            "configs. Files found:\\n\\tconfig2.json \(file-yyy\)\\n\\t"
+            "config3.json \(file-zzz\)"
         )
 
         with pytest.raises(RuntimeError, match=expected_error):

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -10,7 +10,6 @@ import json
 import os
 import re
 import sys
-from time import sleep
 from timeit import default_timer as timer
 from typing import List, Tuple
 


### PR DESCRIPTION
- additional check for only one config file of a given version found, this ensures we unambiguously can select the correct file to use in the case of errors
- addresses https://github.com/eastgenomics/egg5_dias_CEN_config/issues/53

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_dias_batch/182)
<!-- Reviewable:end -->
