### PR TITLE
v3.1.0 - handle dynamic inputs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -282,7 +282,7 @@ The definitions of inputs for CNV calling and each reports workflow should be de
 - `stage_instance_types` (`dict`; optional) : mapping of stage-name to instance type to use, this will override the app and workflow defaults
 - `inputs` (`dict`) : mapping of each stage input field to required input
     - inputs may be defined as regular integers / strings / booleans, `$dnanexus_link` file mappings or using `INPUT-` placeholders
-    - `INPUT-` placeholders are followed by a reference key from the `reference_files` mapping in the top level of the config file, and are parsed at run time into the inputs for the workflow (i.e. use of `"stage-cnv_generate_bed_vep.gene_panels": "INPUT-genepanels"` would result be replace by `project-Fkb6Gkj433GVVvj73J7x8KbV:file-GVx0vkQ433Gvq63k1Kj4Y562`, correctly formatted as a `$dnanexus_link` mapping)
+    - `INPUT-` placeholders may be defined in the config to pass variable inputs such as files and strings at runtime as workflow inputs. See the placeholder section below for details.
     - inputs for the following stages follow the same behaviour as the `bambais` input for the CNV calling app of being provided as a "folder" and "name" key for searching:
         - cnv_reports:
             - `stage-cnv_vep.vcf`
@@ -298,6 +298,18 @@ The definitions of inputs for CNV calling and each reports workflow should be de
             "name": "^[^\.]*(?!\.g)\.vcf(\.gz)?$"
         }
         ```
+
+    ### Placeholders
+    Placeholder strings may be defined in the config file for parsing in reference files and strings that are generated at run time. These are split between the reference files defined in the top level of the config (i.e. the genepanels file) or strings (such as the panel name).
+
+    For reference files, these are followed by a reference key from the `reference_files` mapping in the top level of the config file, and are parsed at run time into the inputs for the workflow (i.e. use of `"stage-cnv_generate_bed_vep.gene_panels": "INPUT-genepanels"` would result be replace by `project-Fkb6Gkj433GVVvj73J7x8KbV:file-GVx0vkQ433Gvq63k1Kj4Y562`, correctly formatted as a `$dnanexus_link` mapping)
+
+    Currently supported placeholder strings include:
+
+    - `INPUT-clinical_indications` : `';'` separated string of clinical indications
+    - `INPUT-panels` : `';'` separated string of panels
+    - `INPUT-test_codes` : `'&&'` separated string of test codes
+    - `INPUT-sample_name` : string of sample name from manifest
 
 ---
 

--- a/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
@@ -1394,7 +1394,6 @@ class TestDXExecuteReportsWorkflow(unittest.TestCase):
         self.workflow_patch = mock.patch('utils.dx_requests.dxpy.DXWorkflow')
         self.describe_patch = mock.patch('utils.dx_requests.dxpy.describe')
         self.timer_patch = mock.patch('utils.dx_requests.timer')
-        self.athena_patch = mock.patch('utils.dx_requests.check_athena_version')
 
 
         self.mock_find = self.find_patch.start()
@@ -1407,7 +1406,6 @@ class TestDXExecuteReportsWorkflow(unittest.TestCase):
         self.mock_workflow = self.workflow_patch.start()
         self.mock_describe = self.describe_patch.start()
         self.mock_timer = self.timer_patch.start()
-        self.mock_athena = self.athena_patch.start()
 
 
         # Below are some generalised expected returns for each of the
@@ -1504,7 +1502,6 @@ class TestDXExecuteReportsWorkflow(unittest.TestCase):
         self.mock_workflow.stop()
         self.mock_describe.stop()
         self.mock_timer.stop()
-        self.mock_athena.stop()
 
     @pytest.fixture(autouse=True)
     def capsys(self, capsys):

--- a/resources/home/dnanexus/dias_batch/tests/test_utils.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_utils.py
@@ -1327,67 +1327,6 @@ class TestAddPanelsAndIndicationsToManifest():
             )
 
 
-class TestCheckAthenaVersion():
-    """
-    Tests for utils.check_athena_version()
-
-    Function checks from the workflow details if eggd_athena/1.6.0+ is
-    being used as this has an additional input, this allows for backwards
-    compatibility with dias_reports using eggd_athena <1.6.0
-
-    We will test that when the eggd_athena app of version 1.4.0 (current
-    in dias reports) is present the input is not added, and when 1.6.0+
-    it is added
-    """
-    def test_version_1_4_0(self):
-        """
-        Test when egdd_athena/1.4.0 is in workflow that the input is
-        not added to the input dict
-        """
-        workflow_details = {
-            "stages": [
-                {
-                    "executable": "eggd_athena/1.4.0"
-                }
-            ]
-        }
-
-        input = utils.check_athena_version(
-            workflow=workflow_details,
-            stage_inputs={},
-            indications='test_indication'
-        )
-
-        assert input == {}, "workflow inputs wrongly modified for athena 1.4.0"
-
-    def test_version_6_4_0(self):
-        """
-        Test when egdd_athena/1.6.0 is in workflow that the indication
-        input is added to the input dict
-        """
-        workflow_details = {
-            "stages": [
-                {
-                    "executable": "eggd_athena/1.6.0"
-                }
-            ]
-        }
-
-        expected_return = {
-            'stage-rpt_athena.indication': 'test_indication'
-        }
-
-        input = utils.check_athena_version(
-            workflow=workflow_details,
-            stage_inputs={},
-            indications='test_indication'
-        )
-
-        assert input == expected_return, (
-            "workflow inputs wrongly modified for athena 1.6.0"
-        )
-
-
 class TestCheckExcludeSamples():
     """
     Tests for utils.check_exclude_samples()

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -18,6 +18,7 @@ from packaging.version import Version
 import pandas as pd
 
 from .utils import (
+    add_dynamic_inputs,
     check_athena_version,
     check_exclude_samples,
     check_report_index,
@@ -1141,6 +1142,14 @@ class DXExecute():
 
                 sample_name_to_suffix[name] = suffix
                 name = f"{name}_{suffix}"
+
+                input = add_dynamic_inputs(
+                    config=input,
+                    clinical_indications=indications,
+                    test_codes=codes,
+                    panels=panels,
+                    sample_name=name
+                )
 
                 # CNV vs SNV stage IDs annoyingly all slight differ,
                 # add required other inputs to where they need to be

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -19,7 +19,6 @@ import pandas as pd
 
 from .utils import (
     add_dynamic_inputs,
-    check_athena_version,
     check_exclude_samples,
     check_report_index,
     filter_manifest_samples_by_files,

--- a/resources/home/dnanexus/dias_batch/utils/utils.py
+++ b/resources/home/dnanexus/dias_batch/utils/utils.py
@@ -11,6 +11,7 @@ from time import strftime, localtime
 from typing import Tuple
 
 import dxpy
+from flatten_dict import flatten, unflatten
 from packaging.version import Version
 import pandas as pd
 
@@ -1100,3 +1101,45 @@ def check_exclude_samples(samples, exclude, mode, single_dir=None) -> dict:
         )
     else:
         print("All exclude sample names valid")
+
+
+def add_dynamic_inputs(config, **kwargs) -> dict:
+    """
+    Adds the given value in place of the placeholder text from assay config
+
+    `kwargs` input are expected to be a mapping of the placeholder as
+    defined in the config without the INPUT- prefix and the input to
+    add in to the config
+
+    Parameters
+    ----------
+    config : dict
+        config with input placeholders to replace
+    kwargs : dict
+        mapping of placeholders to replace and replacement values
+
+    Returns
+    -------
+    dict
+        config with filled placeholders
+    """
+    mapping = {
+        'INPUT-clinical_indications': indications,
+        'INPUT-test_codes': codes,
+        'INPUT-panels': panels,
+        'INPUT-sample_name': name
+    }
+
+    config = flatten_dict(config)
+    filled_config = {}
+
+    for field, config_value in config.items():
+        if kwargs.get(config_value.replace('INPUT-', '')):
+            config_value = kwargs.get(config_value.replace('INPUT-', '')
+
+        filled_config[field] = config_value
+
+    # sense check we removed all placeholders
+    assert not any([x.startswith('INPUT-') for x in filled_config.values()])
+
+    return unflatten(filled_config)

--- a/resources/home/dnanexus/dias_batch/utils/utils.py
+++ b/resources/home/dnanexus/dias_batch/utils/utils.py
@@ -1099,6 +1099,9 @@ def add_dynamic_inputs(config, **kwargs) -> dict:
         filled_config[field] = config_value
 
     # sense check we removed all placeholders
-    assert not any([x.startswith('INPUT-') for x in filled_config.values()])
+    assert not any([
+        x.startswith('INPUT-') if isinstance(x, str) else False
+        for x in filled_config.values()
+    ])
 
     return filled_config

--- a/resources/home/dnanexus/dias_batch/utils/utils.py
+++ b/resources/home/dnanexus/dias_batch/utils/utils.py
@@ -1102,6 +1102,6 @@ def add_dynamic_inputs(config, **kwargs) -> dict:
     assert not any([
         x.startswith('INPUT-') if isinstance(x, str) else False
         for x in filled_config.values()
-    ])
+    ]), f"INPUT- placeholders left in config: {prettier_print(filled_config)}"
 
     return filled_config

--- a/resources/home/dnanexus/dias_batch/utils/utils.py
+++ b/resources/home/dnanexus/dias_batch/utils/utils.py
@@ -1102,6 +1102,6 @@ def add_dynamic_inputs(config, **kwargs) -> dict:
     assert not any([
         x.startswith('INPUT-') if isinstance(x, str) else False
         for x in filled_config.values()
-    ]), f"INPUT- placeholders left in config: {prettier_print(filled_config)}"
+    ]), "INPUT- placeholders left in config"
 
     return filled_config


### PR DESCRIPTION
## Summary
Small update to remove hardcoded stages -> string inputs such as clinical indication and panels, these should now be defined in the config with placeholder text for greater flexibility

## Changes
- add function `utils.add_dynamic_inputs()` to parse in placeholder strings
- add unit tests for new function
- remove old hardcoded stage inputs
- remove unneeded function `utils.check_athena_version()` as the input this added can now be defined from the config

Example config with placeholder inputs in: https://platform.dnanexus.com/panx/projects/GfBY2K84bkgxbx7y3z6q83k9/data/?scope=project&id.values=file-GfkyF3j4bkgXfKXvX1P3Yzx5

Test job launching reports: https://platform.dnanexus.com/panx/projects/GfBY2K84bkgxbx7y3z6q83k9/monitor/job/GfkyF804bkgY1xGf5x3ZjP9q

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_dias_batch/184)
<!-- Reviewable:end -->
