### PR TITLE
v3.1.0 - add running mode to reports folder output name

### DIFF
--- a/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
@@ -992,11 +992,12 @@ class TestDXManageFormatOutputFolders(unittest.TestCase):
         returned_stage_folder = DXManage().format_output_folders(
             workflow=workflow_details,
             single_output='some_output_path',
-            time_stamp='010123_1303'
+            time_stamp='010123_1303',
+            name='workflow1_SNV'
         )
 
         correct_stage_folder = {
-            "stage1": "/some_output_path/workflow1/010123_1303/applet1-v1.2.3/"
+            "stage1": "/some_output_path/workflow1_SNV/010123_1303/applet1-v1.2.3/"
         }
 
         assert correct_stage_folder == returned_stage_folder, (
@@ -1026,7 +1027,8 @@ class TestDXManageFormatOutputFolders(unittest.TestCase):
         returned_stage_folder = DXManage().format_output_folders(
             workflow=workflow_details,
             single_output='some_output_path',
-            time_stamp='010123_1303'
+            time_stamp='010123_1303',
+            name='workflow1'
         )
 
         assert correct_stage_folder == returned_stage_folder, (

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -541,7 +541,7 @@ class DXManage():
         sys.exit(0)
 
 
-    def format_output_folders(self, workflow, single_output, time_stamp) -> dict:
+    def format_output_folders(self, workflow, single_output, time_stamp, name) -> dict:
         """
         Generate dict of output folders for each stage of given workflow
         for passing to dxpy.DXWorkflow().run()
@@ -564,6 +564,8 @@ class DXManage():
             path to single output dir
         time_stamp : str
             time app launched to add to folder path
+        name : str
+            name and mode of reports workflow running
 
         Returns
         -------
@@ -581,9 +583,7 @@ class DXManage():
                 folder_name = stage['executable'].replace(
                     'app-', '', 1).replace('/', '-')
 
-            path = make_path(
-                single_output, workflow['name'], time_stamp, folder_name
-            )
+            path = make_path(single_output, name, time_stamp, folder_name)
 
             stage_folders[stage['id']] = path
 
@@ -1065,15 +1065,19 @@ class DXExecute():
 
         workflow_details = dxpy.describe(workflow_id)
 
+        workflow_name = (
+            f"{workflow_details['name']}_{mode}" if mode in ['SNV', 'mosaic']
+            else workflow_details['name']
+        )
+
         stage_folders = DXManage().format_output_folders(
             workflow=workflow_details,
             single_output=single_output_dir,
-            time_stamp=start
+            time_stamp=start,
+            name=workflow_name
         )
 
-        parent_folder = make_path(
-            single_output_dir, workflow_details['name'], start
-        )
+        parent_folder = make_path(single_output_dir, workflow_name, start)
 
         if not manifest:
             # empty manifest after filtering against files etc


### PR DESCRIPTION
adds in running mode for SNV and mosaic to the reports workflow output directory name to fix #186 

for CNVs this is omitted since the reports workflow name is different and contains CNV so therefore would be redundant.

Example new directory output naming would be:
<img width="858" alt="image" src="https://github.com/eastgenomics/eggd_dias_batch/assets/45037268/ae85f2c7-fcd6-44ae-a0a7-034c69289f1f">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_dias_batch/188)
<!-- Reviewable:end -->
