### PR TITLE
switch split_tests to default to true

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -56,7 +56,7 @@
             "name": "split_tests",
             "label": "split tests",
             "class": "boolean",
-            "optional": true,
+            "default": true,
             "help": "controls if to split multiple panels / genes in a manifest to individual reports instead of being combined into one"
           },
           {


### PR DESCRIPTION
- changes `split_tests` to default to true to fit with new optimised filtering app

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_dias_batch/193)
<!-- Reviewable:end -->
