### PR TITLE
DI-930 fix #195 - correctly check all archived files

### DIFF
--- a/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_dx_requests.py
@@ -749,9 +749,9 @@ class TestDXManageCheckArchivalState(unittest.TestCase):
             match='Files required for analysis archived'
         ):
             DXManage().check_archival_state(
-            sample_files=self.files_w_archive,
-            unarchive=False
-        )
+                sample_files=self.files_w_archive,
+                unarchive=False
+            )
 
 
     def test_archived_files_filtered_out_when_not_in_sample_list(self):
@@ -802,7 +802,7 @@ class TestDXManageCheckArchivalState(unittest.TestCase):
         remove the non sample files
         """
         non_sample_archived_file = [
-                {
+            {
                 'id': 'file-zzz',
                 'describe': {
                     'name': 'some_other_run_level_file.bed',
@@ -828,7 +828,7 @@ class TestDXManageCheckArchivalState(unittest.TestCase):
                 "some_other_run_level_file.bed (file-zzz) - archived"
             )
 
-            assert  archived_bed_stdout in self.capsys.readouterr().out, (
+            assert archived_bed_stdout in self.capsys.readouterr().out, (
                 'Archived bed not correctly identified as archived'
             )
 
@@ -847,7 +847,7 @@ class TestDXManageCheckArchivalState(unittest.TestCase):
                 "some_other_run_level_file.bed (file-zzz) - archived"
             )
 
-            assert  archived_bed_stdout in self.capsys.readouterr().out, (
+            assert archived_bed_stdout in self.capsys.readouterr().out, (
                 'Archived bed not correctly identified as archived'
             )
 


### PR DESCRIPTION
- Fixes #195
- Corrects behaviour where the intervals bed file from CNV calling to go to CNV reports would wrongly get removed from checking for files to unarchive, and as such would not be unarchived

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_dias_batch/200)
<!-- Reviewable:end -->
