### PR TITLE
DI-930 fix #197 - fix skipping samples with missing test codes

### DIFF
--- a/resources/home/dnanexus/dias_batch/tests/test_utils.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_utils.py
@@ -1062,9 +1062,15 @@ class TestCheckManifestValidTestCodes():
         """
         # drop test codes for a manifest sample
         manifest_copy = deepcopy(self.manifest)
+        manifest_copy['324338111-43206R00111']['tests'] = []
         manifest_copy['424487111-53214R00111']['tests'] = [[]]
 
-        with pytest.raises(RuntimeError, match=r"No tests booked for sample"):
+        expected_error = re.escape(
+            "'324338111-43206R00111': ['No tests booked for sample'], "
+            "'424487111-53214R00111': ['No tests booked for sample']"
+        )
+
+        with pytest.raises(RuntimeError, match=expected_error):
             utils.check_manifest_valid_test_codes(
                 manifest=manifest_copy, genepanels=self.genepanels
             )

--- a/resources/home/dnanexus/dias_batch/utils/utils.py
+++ b/resources/home/dnanexus/dias_batch/utils/utils.py
@@ -732,7 +732,7 @@ def check_manifest_valid_test_codes(manifest, genepanels) -> dict:
     for sample, test_codes in manifest.items():
         sample_invalid_test = []
 
-        if test_codes['tests'] == [[]]:
+        if [x for x in test_codes['tests'] if x] == []:
             # sample has no booked tests => chuck it in the error bucket
             invalid[sample].append('No tests booked for sample')
             continue


### PR DESCRIPTION
- Fixes #197 
- Fixes where samples with no test codes were being skipped instead of raising an error, will now correctly raise a RuntimeError

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_dias_batch/201)
<!-- Reviewable:end -->
