### PR TITLE
DI-930 fix #198 - allow invalid samples in manifest when subsetting

### DIFF
--- a/resources/home/dnanexus/dias_batch/utils/utils.py
+++ b/resources/home/dnanexus/dias_batch/utils/utils.py
@@ -555,6 +555,18 @@ def parse_manifest(contents, split_tests=False, subset=None) -> Tuple[pd.DataFra
             elif re.match(r"[\d\w]+-[\d\w]+", row.SampleID):
                 data[row.SampleID]['tests'].append(test_codes)
                 manifest_source[row.SampleID] = {'manifest_source': 'Epic'}
+            elif subset:
+                # sampleID and reanalysisID don't seem valid, continue
+                # anyway if we're subsetting and assume that the user
+                # knows what they're doing, if the samples specified to
+                # --subset don't exist in the manifest this will still
+                # raise a RuntimeError below
+                print(
+                    f"Row {idx + 1} of manifest does not seem to contain all "
+                    "required identifiers, --subset specified so will skip "
+                    f"this row:\n\t{row.tolist()}"
+                )
+                continue
             else:
                 # something funky with this sample naming
                 raise RuntimeError(


### PR DESCRIPTION
- Fixes #198 
- When an invalid sample identifier / missing is present in the manifest, this would normally raise an error on parsing
- This will now not raise an error if `-isubset` is provided, and all sample IDs provided to `-isubset` are valid

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_dias_batch/202)
<!-- Reviewable:end -->
