### PR TITLE
DI-930 fix #207 strip whitespace from inputs

### DIFF
--- a/resources/home/dnanexus/dias_batch/dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/dias_batch.py
@@ -71,6 +71,7 @@ class CheckInputs():
         self.check_exclude_str_and_file()
         self.check_exclude_samples_file_id()
         self.check_qc_file()
+        self.strip_string_inputs()
 
         if self.errors:
             errors = '; '.join(x for x in self.errors)
@@ -250,6 +251,24 @@ class CheckInputs():
                     "rerun and provide this as -iexclude_samples_file="
                     f"{self.inputs.get('exclude_samples')}"
                 )
+
+    def strip_string_inputs(self):
+        """
+        Strip string type inputs to ensure no leading or trailing
+        whitespace are retained
+        """
+        string_inputs = [
+            'assay',
+            'assay_config_dir',
+            'exclude_samples',
+            'manifest_subset',
+            'single_output_dir',
+            'cnv_call_job_id'
+        ]
+
+        for string in string_inputs:
+            if self.inputs.get(string) and isinstance(self.inputs.get(string), str):
+                self.inputs[string] = self.inputs[string].strip()
 
 
 @dxpy.entry_point('main')

--- a/resources/home/dnanexus/dias_batch/tests/test_dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/tests/test_dias_batch.py
@@ -258,6 +258,37 @@ class TestCheckInputs():
             "Error not raised when non .xlsx file provided to check_qc_file()"
         )
 
+    def test_string_inputs_with_whitespace_stripped(self, mocker):
+        """
+        Test that string inputs are correctly stripped
+        """
+        mocker.patch.object(CheckInputs, "__init__", return_value=None)
+        check = CheckInputs()
+
+        check.inputs = {
+            'assay': 'CEN ',
+            'assay_config_dir': ' some_dir',
+            'exclude_samples': ' sample1 ',
+            'manifest_subset': ' ',
+            'single_output_dir': '/output/foo/bar',
+            'cnv_call_job_id': 'job-xxx '
+        }
+
+        check.strip_string_inputs()
+
+        expected_inputs = {
+            'assay': 'CEN',
+            'assay_config_dir': 'some_dir',
+            'exclude_samples': 'sample1',
+            'manifest_subset': '',
+            'single_output_dir': '/output/foo/bar',
+            'cnv_call_job_id': 'job-xxx'
+        }
+
+        assert check.inputs == expected_inputs, (
+            'String inputs not correctly stripped'
+        )
+
 
 class TestMain():
     """


### PR DESCRIPTION
- adds new function `CheckInputs.strip_string_inputs` to ensure all string inputs have no leading / trailing whitespace
  - fixes #207 
- add unit test for new function

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_dias_batch/208)
<!-- Reviewable:end -->
