### PR TITLE
IN-930 - fix #196 better unarchival checking

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,8 @@ DNAnexus app for launching CNV calling, one or more of SNV, CNV and mosaic repor
 
 The app takes as a minimum input a path to Dias single output, an assay config, and at least one of the above listed running modes. The default behaviour is to pass an assay string specified to run for (with `-iassay`), which will search DNAnexus for the highest version config file in `-iassay_config_dir`  (default: `001_Reference:/dynamic_files/dias_batch_configs/`)  and use this for analysis. Alternatively, an assay config file may be specified to use instead with `-iassay_config_file`. If running a reports workflow a manifest file must also be specified.
 
+Before any jobs are launched, a check of the archival state of all required files is first made. This will use the file pattern mappings either defined in `utils.defaults` or from the assay config file (if specified) to search for the per sample and per run files required, any will raise an error on any archived files if `unarchive=True` is not set.
+
 The general behaviour of each mode is as follows:
 
 ### CNV calling
@@ -221,6 +223,7 @@ The top level section should be structured as follows:
 - `{cnv_call_app|_report_workflow}_id` (`str`) : the IDs of CNV calling and reports workflows to use
 - `reference_files` (`dict`) : mapping of reference file name : DNAnexus file ID, reference file name _must_ be given as shown above, and DNAnexus file ID should be provided as `project-xxx:file-xxx`
 - `name_patterns` (`dict`) : mapping of the manifest source and a regex pattern to use for filtering sample names and files etc.
+- `mode_file_patterns` (`dict` | optional): mapping for each running mode to sample and run file patterns for which to search and check the archival state of before launching any jobs. Defaults are defined in `utils.defaults`, and a mapping of the same structure may be added to the assay config file to override the defaults.
 
 The definitions of inputs for CNV calling and each reports workflow should be defined under the key `modes`, containing a mapping of all inputs and other inputs for controlling running of analyses.
 

--- a/resources/home/dnanexus/dias_batch/dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/dias_batch.py
@@ -384,42 +384,6 @@ def main(
 
     # check up front if any files for any of the selected running modes
     # are in an archived state which would cause jobs to fail to launch
-    # mode_file_patterns = assay_config.get('mode_file_patterns')
-
-
-        # mode_file_patterns = {
-        #     'cnv_reports': {
-        #         'sample': [
-        #             '_segments.vcf$'
-        #         ],
-        #         'run': [
-        #             '_excluded_intervals.bed$'
-        #         ]
-        #     },
-        #     'snv_reports': {
-        #         'sample': [
-        #             '_markdup_recalibrated_Haplotyper.vcf.gz$',
-        #             'per-base.bed.gz$',
-        #             'reference_build.txt$'
-        #         ],
-        #         'run': []
-        #     },
-        #     'mosaic_reports': {
-        #         'sample': [
-        #             '_markdup_recalibrated_tnhaplotyper2.vcf.gz',
-        #             'per-base.bed.gz$',
-        #             'reference_build.txt$'
-        #         ],
-        #         'run': []
-        #     },
-        #     'artemis': {
-        #         'bam$',
-        #         'bam.bai$',
-        #         '_copy_ratios.gcnv.bed$',
-        #         '_copy_ratios.gcnv.bed.tbi$'
-        #     }
-        # }
-
     DXManage().check_all_files_archival_state(
         patterns=assay_config.get('mode_file_patterns'),
         samples=manifest.keys(),

--- a/resources/home/dnanexus/dias_batch/dias_batch.py
+++ b/resources/home/dnanexus/dias_batch/dias_batch.py
@@ -382,6 +382,56 @@ def main(
             for sample in manifest
         }
 
+    # check up front if any files for any of the selected running modes
+    # are in an archived state which would cause jobs to fail to launch
+    # mode_file_patterns = assay_config.get('mode_file_patterns')
+
+
+        # mode_file_patterns = {
+        #     'cnv_reports': {
+        #         'sample': [
+        #             '_segments.vcf$'
+        #         ],
+        #         'run': [
+        #             '_excluded_intervals.bed$'
+        #         ]
+        #     },
+        #     'snv_reports': {
+        #         'sample': [
+        #             '_markdup_recalibrated_Haplotyper.vcf.gz$',
+        #             'per-base.bed.gz$',
+        #             'reference_build.txt$'
+        #         ],
+        #         'run': []
+        #     },
+        #     'mosaic_reports': {
+        #         'sample': [
+        #             '_markdup_recalibrated_tnhaplotyper2.vcf.gz',
+        #             'per-base.bed.gz$',
+        #             'reference_build.txt$'
+        #         ],
+        #         'run': []
+        #     },
+        #     'artemis': {
+        #         'bam$',
+        #         'bam.bai$',
+        #         '_copy_ratios.gcnv.bed$',
+        #         '_copy_ratios.gcnv.bed.tbi$'
+        #     }
+        # }
+
+    DXManage().check_all_files_archival_state(
+        patterns=assay_config.get('mode_file_patterns'),
+        samples=manifest.keys(),
+        unarchive=unarchive,
+        modes={
+            'cnv_reports': cnv_reports,
+            'snv_reports': snv_reports,
+            'mosaic_reports': mosaic_reports,
+            'artemis': artemis
+        }
+    )
+
     launched_jobs = {}
     cnv_report_errors = snv_report_errors = mosaic_report_errors = \
         cnv_call_excluded_files = cnv_report_summary = snv_report_summary = \

--- a/resources/home/dnanexus/dias_batch/utils/defaults.py
+++ b/resources/home/dnanexus/dias_batch/utils/defaults.py
@@ -1,0 +1,32 @@
+default_mode_file_patterns = {
+    'cnv_reports': {
+        'sample': [
+            '_segments.vcf$'
+        ],
+        'run': [
+            '_excluded_intervals.bed$'
+        ]
+    },
+    'snv_reports': {
+        'sample': [
+            '_markdup_recalibrated_Haplotyper.vcf.gz$',
+            'per-base.bed.gz$',
+            'reference_build.txt$'
+        ],
+        'run': []
+    },
+    'mosaic_reports': {
+        'sample': [
+            '_markdup_recalibrated_tnhaplotyper2.vcf.gz',
+            'per-base.bed.gz$',
+            'reference_build.txt$'
+        ],
+        'run': []
+    },
+    'artemis': {
+        'bam$',
+        'bam.bai$',
+        '_copy_ratios.gcnv.bed$',
+        '_copy_ratios.gcnv.bed.tbi$'
+    }
+}

--- a/resources/home/dnanexus/dias_batch/utils/defaults.py
+++ b/resources/home/dnanexus/dias_batch/utils/defaults.py
@@ -24,9 +24,11 @@ default_mode_file_patterns = {
         'run': []
     },
     'artemis': {
-        'bam$',
-        'bam.bai$',
-        '_copy_ratios.gcnv.bed$',
-        '_copy_ratios.gcnv.bed.tbi$'
+        'sample':[
+            'bam$',
+            'bam.bai$',
+            '_copy_ratios.gcnv.bed$',
+            '_copy_ratios.gcnv.bed.tbi$'
+        ]
     }
 }

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -457,8 +457,6 @@ class DXManage():
                 unarchive=unarchive
             )
 
-        exit()
-
 
     def check_archival_state(
             self,

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -715,26 +715,6 @@ class DXManage():
         return stage_folders
 
 
-    def remove_job_tags(self) -> None:
-        """
-        Checks for presence of job tags relating to unarchiving on
-        launching, any of these present suggests the job has been cloned
-        and therefore not relating to the current job
-        """
-        job = dxpy.DXJob(dxid=os.environ.get('DX_JOB_ID'))
-        current_tags = job.describe(fields={'tags': True}).get('tags')
-
-        unarchive_tags = [
-            tag for tag in current_tags if re.match(
-                r'Unarchiving of [\d]+ requested, no jobs launched', tag
-            )
-        ]
-
-        if unarchive_tags:
-            print("Removing old archive tag(s)  from job")
-            job.remove_tags(unarchive_tags)
-
-
 class DXExecute():
     """
     Methods for handling execution of apps / workflows

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -367,7 +367,7 @@ class DXManage():
         path,
         modes,
         unarchive
-        ) -> list:
+        ):
         """
         Checks for all specified file patterns and samples for each
         running mode to ensure they are unarchived before attempting
@@ -386,13 +386,9 @@ class DXManage():
         unarchive : bool
             if to automatically unarchive files, will be passed through
             to self.check_archival_state
-
-        Returns
-        -------
-        list
-            _description_
         """
-        print("\nChecking archival states for all selected running modes")
+        print("\nChecking archival states for selected running modes:")
+        prettier_print(modes)
 
         if not patterns:
             # file patterns to check per running mode not defined in config,
@@ -412,6 +408,7 @@ class DXManage():
 
         for mode, selected in modes.items():
             if not selected:
+                print(f'Running mode {mode} not selected, skipping file check')
                 continue
 
             mode_sample_patterns = patterns.get(mode, {}).get('sample')

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -390,9 +390,6 @@ class DXManage():
         """
         print("\nChecking archival states for all selected running modes")
 
-        sample_files_to_check = []
-        run_files_to_check = []
-
         if not patterns:
             # file patterns to check per running mode not defined in config,
             # use current patterns correct as of 12/07/2024 as default
@@ -401,21 +398,34 @@ class DXManage():
                 "No mode file patterns defined in assay config, using "
                 "default values from utils.defaults"
             )
-            patterns = default_mode_file_patterns
+            patterns = dict(default_mode_file_patterns)
+
+        for x, y in patterns.items():
+            print(x, y)
+
+        print('all samples: ', samples)
+
+        sample_files_to_check = []
+        run_files_to_check = []
 
         for mode, _ in modes.items():
+            print(mode)
             if not mode:
                 continue
 
+
             mode_sample_patterns = patterns.get(mode, {}).get('sample')
             mode_run_patterns = patterns.get(mode, {}).get('run')
+
+            print(mode_sample_patterns)
+            print(mode_run_patterns)
 
             if mode_sample_patterns:
                 # generate regex pattern per sample for each file pattern,
                 # then join it as one big chongus pattern for a single query
                 # because its not our API server load to worry about
                 sample_patterns = '|'.join([
-                    [f"{x}.*{y}" for x in samples for y in mode_sample_patterns]
+                    f"{x}.*{y}" for x in samples for y in mode_sample_patterns
                 ])
                 print(
                     f"Searching per sample files for {mode} with "
@@ -442,11 +452,12 @@ class DXManage():
             f"{len(run_files_to_check)} run level files to check"
         )
 
-        self.check_archival_state(
-            sample_files=sample_files_to_check,
-            non_sample_files=run_files_to_check,
-            unarchive=unarchive
-        )
+        if sample_files_to_check or run_files_to_check:
+            self.check_archival_state(
+                sample_files=sample_files_to_check,
+                non_sample_files=run_files_to_check,
+                unarchive=unarchive
+            )
 
         exit()
 

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -251,7 +251,9 @@ class DXManage():
         list
             list of files found
         """
-        path = path.rstrip('/')
+        if path != '/':
+            path = path.rstrip('/')
+
         if subdir:
             subdir = subdir.strip('/')
 

--- a/resources/home/dnanexus/dias_batch/utils/dx_requests.py
+++ b/resources/home/dnanexus/dias_batch/utils/dx_requests.py
@@ -402,25 +402,18 @@ class DXManage():
             )
             patterns = dict(default_mode_file_patterns)
 
-        for x, y in patterns.items():
-            print(x, y)
-
-        print('all samples: ', samples)
+        print("Currently defined patterns:")
+        prettier_print(patterns)
 
         sample_files_to_check = []
         run_files_to_check = []
 
-        for mode, _ in modes.items():
-            print(mode)
-            if not mode:
+        for mode, selected in modes.items():
+            if not selected:
                 continue
-
 
             mode_sample_patterns = patterns.get(mode, {}).get('sample')
             mode_run_patterns = patterns.get(mode, {}).get('run')
-
-            print(mode_sample_patterns)
-            print(mode_run_patterns)
 
             if mode_sample_patterns:
                 # generate regex pattern per sample for each file pattern,
@@ -434,7 +427,6 @@ class DXManage():
                     f"{len(mode_sample_patterns)} patterns for {len(samples)} "
                     "samples"
                 )
-                print(sample_patterns)
 
                 sample_files_to_check.extend(self.find_files(
                     pattern=sample_patterns
@@ -451,7 +443,7 @@ class DXManage():
 
         print(
             f"Found {len(sample_files_to_check)} sample files and "
-            f"{len(run_files_to_check)} run level files to check"
+            f"{len(run_files_to_check)} run level files to check status of"
         )
 
         if sample_files_to_check or run_files_to_check:


### PR DESCRIPTION
## Summary
Improves checking of archived files before attempting to launch any jobs to fix #196 

## Changes
- addition of `dx_requests.check_all_files_archival_state`
  - function checks running modes selected and searches for all defined file types for each sample in manifest, and then calls `dx_requests.check_archival_state` to determine if any files for any jobs will be archived
  - add required patterns for files to `utils.defaults`
    - this will also be able to be defined in the assay config file to overwrite this as needed
- add unit tests for new functionality

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_dias_batch/209)
<!-- Reviewable:end -->
